### PR TITLE
Add `--allow-same-version` to `npm version` command for npm-publish workflow.

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -52,7 +52,7 @@ jobs:
       - run: git config --global user.email "github-action-${{ github.actor }}@users.noreply.github.com"
 
       - name: Tag NPM version
-        run: npm version ${{ github.event.release.tag_name }}
+        run: npm version --allow-same-version ${{ github.event.release.tag_name }}
 
       - name: Publish to NPM Registry
         run: npm publish


### PR DESCRIPTION
Error Received From Workflow
```
Run npm version v1.14.3-cucwd
  npm version v1.14.3-cucwd
  shell: /usr/bin/bash -e {0}
  env:
    NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
    NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
  
npm ERR! code 128
npm ERR! An unknown git error occurred
npm ERR! command /usr/bin/git --no-replace-objects tag -m 1.14.3-cucwd v1.14.3-cucwd
npm ERR! fatal: tag 'v1.14.3-cucwd' already exists
```