### PR TITLE
Only publish the `./dist` folder to `npmjs` for the `npm-publish` workflow.

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -59,6 +59,10 @@ jobs:
       - name: Tag NPM version
         run: npm version --allow-same-version ${{ github.event.release.tag_name }}
 
+      # https://stackoverflow.com/questions/38935176/how-to-npm-publish-specific-folder-but-as-package-root
+      - name: Copy `package.json` into `./dist` directory then cd into that folder before publishing to npmjs.
+        run: cd package.json ./dist && cd ./dist
+
       - name: Publish to NPM Registry
         run: npm publish --userconfig .npmrc --registry https://registry.npmjs.org/
         env:


### PR DESCRIPTION
Since the `release` workflow uses the `semantic-release` it includes a `.releaserc` file configuring which directory needs to be release to `npmjs` repository. We're not using `semantic-release` with this `npm-publish` workflow and therefore need to build the npm packing from within the `./dist` directory to only include those files.

The `.npmignore` is supposed to ignore certain files, however, when viewing how edX builds its npm package they only had the contents of the `./dist` and nothing else.